### PR TITLE
feat: Implement reactive repository with in-memory cache and filtering

### DIFF
--- a/app/src/main/java/co/pacastrillon/harrypottercharacter/character/CharactersViewModel.kt
+++ b/app/src/main/java/co/pacastrillon/harrypottercharacter/character/CharactersViewModel.kt
@@ -2,32 +2,54 @@ package co.pacastrillon.harrypottercharacter.character
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import co.pacastrillon.harrypottercharacter.domain.repository.CharactersRepository
+import co.pacastrillon.harrypottercharacter.domain.model.Filter
+import co.pacastrillon.harrypottercharacter.domain.usecase.ObserveCharactersUseCase
+import co.pacastrillon.harrypottercharacter.domain.usecase.RefreshCharactersUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
+@OptIn(ExperimentalCoroutinesApi::class)
 @HiltViewModel
 class CharactersViewModel @Inject constructor(
-    private val repo: CharactersRepository
+    private val observeCharacters: ObserveCharactersUseCase,
+    private val refreshCharacters: RefreshCharactersUseCase
 ) : ViewModel() {
+
+    private val filter = MutableStateFlow<Filter>(Filter.All)
 
     private val _uiState = MutableStateFlow<CharactersUiState>(CharactersUiState.Idle)
     val uiState: StateFlow<CharactersUiState> = _uiState.asStateFlow()
 
-    fun getCharacters() {
+    init {
         viewModelScope.launch {
-            _uiState.value = CharactersUiState.Loading
-            runCatching { repo.getCharacters() }
-                .onSuccess { list ->
+            filter.flatMapLatest { observeCharacters(it) }
+                .collect { list ->
                     _uiState.value = CharactersUiState.Success(list)
                 }
+        }
+        refresh()
+    }
+
+    fun setFilter(newFilter: Filter) {
+        filter.value = newFilter
+        refresh()
+    }
+
+    fun refresh() {
+        viewModelScope.launch {
+            _uiState.value = CharactersUiState.Loading
+            runCatching { refreshCharacters(filter.value) }
                 .onFailure { e ->
                     _uiState.value = CharactersUiState.Error(e.message ?: "Unknown error")
                 }
         }
     }
+
+    fun getCharacters() = refresh()
 }

--- a/data/src/main/java/co/pacastrillon/harrypottercharacter/data/mapper/CharacterDtoToCharacterMapper.kt
+++ b/data/src/main/java/co/pacastrillon/harrypottercharacter/data/mapper/CharacterDtoToCharacterMapper.kt
@@ -2,10 +2,19 @@ package co.pacastrillon.harrypottercharacter.data.mapper
 
 import co.pacastrillon.harrypottercharacter.data.remote.dto.CharacterDto
 import co.pacastrillon.harrypottercharacter.domain.model.Character
+import java.util.Locale
 
-fun CharacterDto.toCharacter(): Character = Character(
-    id = id,
-    name = name,
-    house = house,
-    image = image
-)
+fun CharacterDto.toCharacter(): Character {
+    val stableId = id?.takeIf { it.isNotBlank() } ?: run {
+        val base = (name.trim() + "|" + (actor ?: "").trim())
+            .lowercase(Locale.ROOT)
+        base.hashCode().toString()
+    }
+
+    return Character(
+        id = stableId,
+        name = name,
+        house = house,
+        image = image
+    )
+}

--- a/data/src/main/java/co/pacastrillon/harrypottercharacter/data/repository/CharactersRepositoryImpl.kt
+++ b/data/src/main/java/co/pacastrillon/harrypottercharacter/data/repository/CharactersRepositoryImpl.kt
@@ -3,14 +3,50 @@ package co.pacastrillon.harrypottercharacter.data.repository
 import co.pacastrillon.harrypottercharacter.data.mapper.toCharacter
 import co.pacastrillon.harrypottercharacter.data.remote.HpApiService
 import co.pacastrillon.harrypottercharacter.domain.model.Character
+import co.pacastrillon.harrypottercharacter.domain.model.Filter
 import co.pacastrillon.harrypottercharacter.domain.repository.CharactersRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import javax.inject.Inject
+import javax.inject.Singleton
 
+@Singleton
 class CharactersRepositoryImpl @Inject constructor(
     private val api: HpApiService
 ) : CharactersRepository {
 
-    override suspend fun getCharacters(): List<Character> =
-        api.getCharacters().map { it.toCharacter() }
+    private val mutex = Mutex()
 
+    private val cacheByFilter = MutableStateFlow<Map<Filter, List<Character>>>(emptyMap())
+    private val cacheById = MutableStateFlow<Map<String, Character>>(emptyMap())
+
+    override fun observeCharacters(filter: Filter): Flow<List<Character>> =
+        cacheByFilter.map { it[filter].orEmpty() }.distinctUntilChanged()
+
+    override fun observeCharacter(id: String): Flow<Character?> =
+        cacheById.map { it[id] }.distinctUntilChanged()
+
+    override suspend fun refreshCharacters(filter: Filter) {
+        val remote = when (filter) {
+            Filter.All -> api.getCharacters()
+            Filter.Students -> api.getStudents()
+            Filter.Staff -> api.getStaff()
+            is Filter.House -> api.getByHouse(filter.name)
+        }
+
+        val domainList = remote.map { it.toCharacter() }
+
+        mutex.withLock {
+            cacheByFilter.value = cacheByFilter.value.toMutableMap().apply {
+                put(filter, domainList)
+            }
+            cacheById.value = cacheById.value.toMutableMap().apply {
+                domainList.forEach { put(it.id, it) }
+            }
+        }
+    }
 }

--- a/domain/src/main/java/co/pacastrillon/harrypottercharacter/domain/model/Character.kt
+++ b/domain/src/main/java/co/pacastrillon/harrypottercharacter/domain/model/Character.kt
@@ -1,7 +1,7 @@
 package co.pacastrillon.harrypottercharacter.domain.model
 
 data class Character(
-    val id: String?,
+    val id: String,
     val name: String,
     val house: String?,
     val image: String?

--- a/domain/src/main/java/co/pacastrillon/harrypottercharacter/domain/model/Filter.kt
+++ b/domain/src/main/java/co/pacastrillon/harrypottercharacter/domain/model/Filter.kt
@@ -1,0 +1,8 @@
+package co.pacastrillon.harrypottercharacter.domain.model
+
+sealed interface Filter {
+    data object All : Filter
+    data object Students : Filter
+    data object Staff : Filter
+    data class House(val name: String) : Filter
+}

--- a/domain/src/main/java/co/pacastrillon/harrypottercharacter/domain/repository/CharactersRepository.kt
+++ b/domain/src/main/java/co/pacastrillon/harrypottercharacter/domain/repository/CharactersRepository.kt
@@ -1,6 +1,11 @@
 package co.pacastrillon.harrypottercharacter.domain.repository
+
 import co.pacastrillon.harrypottercharacter.domain.model.Character
+import co.pacastrillon.harrypottercharacter.domain.model.Filter
+import kotlinx.coroutines.flow.Flow
 
 interface CharactersRepository {
-    suspend fun getCharacters(): List<Character>
+    fun observeCharacters(filter: Filter): Flow<List<Character>>
+    suspend fun refreshCharacters(filter: Filter)
+    fun observeCharacter(id: String): Flow<Character?>
 }

--- a/domain/src/main/java/co/pacastrillon/harrypottercharacter/domain/usecase/ObserveCharacterUseCase.kt
+++ b/domain/src/main/java/co/pacastrillon/harrypottercharacter/domain/usecase/ObserveCharacterUseCase.kt
@@ -1,0 +1,12 @@
+package co.pacastrillon.harrypottercharacter.domain.usecase
+
+import co.pacastrillon.harrypottercharacter.domain.model.Character
+import co.pacastrillon.harrypottercharacter.domain.repository.CharactersRepository
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class ObserveCharacterUseCase @Inject constructor(
+    private val repo: CharactersRepository
+) {
+    operator fun invoke(id: String): Flow<Character?> = repo.observeCharacter(id)
+}

--- a/domain/src/main/java/co/pacastrillon/harrypottercharacter/domain/usecase/ObserveCharactersUseCase.kt
+++ b/domain/src/main/java/co/pacastrillon/harrypottercharacter/domain/usecase/ObserveCharactersUseCase.kt
@@ -1,0 +1,13 @@
+package co.pacastrillon.harrypottercharacter.domain.usecase
+
+import co.pacastrillon.harrypottercharacter.domain.model.Character
+import co.pacastrillon.harrypottercharacter.domain.model.Filter
+import co.pacastrillon.harrypottercharacter.domain.repository.CharactersRepository
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class ObserveCharactersUseCase @Inject constructor(
+    private val repo: CharactersRepository
+) {
+    operator fun invoke(filter: Filter): Flow<List<Character>> = repo.observeCharacters(filter)
+}

--- a/domain/src/main/java/co/pacastrillon/harrypottercharacter/domain/usecase/RefreshCharactersUseCase.kt
+++ b/domain/src/main/java/co/pacastrillon/harrypottercharacter/domain/usecase/RefreshCharactersUseCase.kt
@@ -1,0 +1,11 @@
+package co.pacastrillon.harrypottercharacter.domain.usecase
+
+import co.pacastrillon.harrypottercharacter.domain.model.Filter
+import co.pacastrillon.harrypottercharacter.domain.repository.CharactersRepository
+import javax.inject.Inject
+
+class RefreshCharactersUseCase @Inject constructor(
+    private val repo: CharactersRepository
+) {
+    suspend operator fun invoke(filter: Filter) = repo.refreshCharacters(filter)
+}


### PR DESCRIPTION
This commit refactors the data layer to be reactive using Kotlin Flows and introduces an in-memory caching strategy. It also adds filtering capabilities and the corresponding use cases.

- **Repository & Caching (`data` module):**
    - Modifies `CharactersRepository` to expose `Flows` for observing data changes (`observeCharacters`, `observeCharacter`).
    - Implements `CharactersRepositoryImpl` as a singleton with an in-memory cache using `MutableStateFlow` to store character lists by filter and by ID.
    - Adds a `refreshCharacters` suspend function to fetch data from the remote API and update the cache.
    - Uses a `Mutex` to ensure thread-safe writes to the cache.

- **Domain Layer:**
    - Adds a `Filter` sealed interface to represent different character filtering options (`All`, `Students`, `Staff`, `House`).
    - Introduces `ObserveCharactersUseCase`, `ObserveCharacterUseCase`, and `RefreshCharactersUseCase` to interact with the new repository methods.
    - Changes the `id` property in the `Character` model to be non-nullable.

- **ViewModel (`app` module):**
    - Updates `CharactersViewModel` to use the new reactive use cases.
    - It now observes a `Flow` of characters based on the current `Filter` and updates the UI state automatically.
    - Adds `setFilter` and `refresh` functions to manage data fetching and filtering logic.

- **Mapper (`data` module):**
    - Enhances the `toCharacter()` mapper to generate a stable, non-null `id` for characters by creating a hash from the character's name and actor if the original ID is missing.